### PR TITLE
Prevent overflow problems with expanded ToC

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,10 +1,15 @@
 
 /* blockquote */
 .dokuwiki blockquote.blockquote-plugin {
-    margin: 1em 3em 1em 3em;
     border: 1px dotted __border__;
     background: __background_alt__ url(images/blockquote.gif) no-repeat 0.3em 0.3em;
     padding: 1em;
+    /* prevent plugin to interfere with expanded ToC when there's one */
+    overflow: hidden;
+    /* Fix placement with the rule above (original margins were: 1em 3em 1em 3em */
+    margin: 1em auto 1em auto;
+    /* Get closer to initial design when there's enough space (ie. 3em left and right margins) */
+    max-width: 90%;
 }
 
 /* cite */


### PR DESCRIPTION
By default, ToC will interfere with Blockquote blocks like this : 
![image](https://cloud.githubusercontent.com/assets/8507657/24350893/3688a084-12e4-11e7-9061-35939eb37db8.png)

This PR makes sure a Blockquote div will not be hidden under ToC : 
![image](https://cloud.githubusercontent.com/assets/8507657/24350980/7cd7a346-12e4-11e7-8a1a-95c3f3deab09.png)
